### PR TITLE
Minor Fixes in Makefile and get_next_non_listed_id()

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -76,7 +76,7 @@ $(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
 # Build application binary
 $(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $(CFLAGS) $^ -l:libz.a -l:libelf.a --static -o bin/$@
+	$(Q)$(CC) $(CFLAGS) $^ -l:libz.a -l:libelf.a -l:libzstd.a --static -o bin/$@
 	$(Q)$(STRIP) bin/$@
 
 # Build helpers

--- a/src/nysm.bpf.c
+++ b/src/nysm.bpf.c
@@ -248,7 +248,7 @@ static int bpf_map_read_elem(void *dst, int size, void *map, int key) {
 static uint32_t get_next_non_listed_id(void *map, uint32_t id) {
 
     if (!bpf_map_lookup_elem(map, &id)) return 0;
-    for (int i=0;i<256;i++) {
+    for (int i=0;i<1024;i++) {
         id++;
         if (!bpf_map_lookup_elem(map, &id)) break;
     }


### PR DESCRIPTION
- Fixed Makefile for static compilation 
- Corrected max iterations in get_next_non_listed_id() from 256 to 1024 (as defined by max_entries in maps)